### PR TITLE
Sourcery Reviewed PR

### DIFF
--- a/advent_of_code_day1.py
+++ b/advent_of_code_day1.py
@@ -20,14 +20,11 @@ def advent_of_code_day_1_part_1():
   for item in expense_report:
     for second_item in expense_report:
       if (item + second_item == 2020):
-        if len(eligible_items) < 1:
-          eligible_items.append(item)
-          eligible_items.append(second_item)
-        else:
+        if eligible_items:
           if item not in [eligible_items[0], eligible_items[1]]:
-            eligible_items.append(item)
-            eligible_items.append(second_item)
-
+            eligible_items.extend((item, second_item))
+        else:
+          eligible_items.extend((item, second_item))
   print('Part one results:')
   print('the two numbers are:')
   print(eligible_items)
@@ -41,13 +38,13 @@ def advent_of_code_day_1_part_2():
     for second_item in expense_report:
       for third_item in expense_report:
         if (item + second_item + third_item == 2020):
-          if len(eligible_items) < 1:
-            advent_of_code_day_1_part_2_append_found_numbers(eligible_items, item,
-                                                          second_item, third_item)
-          else:
+          if eligible_items:
             if item not in [eligible_items[0], eligible_items[1], eligible_items[2]]:
               advent_of_code_day_1_part_2_append_found_numbers(eligible_items, item,
                                                             second_item, third_item)
+          else:
+            advent_of_code_day_1_part_2_append_found_numbers(eligible_items, item,
+                                                          second_item, third_item)
   print('Part two results:')
   print('the three numbers are:')
   print(eligible_items)

--- a/advent_of_code_day2.py
+++ b/advent_of_code_day2.py
@@ -14,8 +14,8 @@ def parser(input_string):
   return lower_limit, upper_limit, letter, test_password
 
 def part_1_password_check(lower_bound, upper_bound, rule_letter, password_to_test):
-  letter_count = sum(1 for i in range(len(password_to_test))
-                     if password_to_test[i] == rule_letter)
+  letter_count = sum(
+      password_to_test[i] == rule_letter for i in range(len(password_to_test)))
   return letter_count >= lower_bound and letter_count <= upper_bound
 
 def part_1_check_full_list():
@@ -35,17 +35,10 @@ print(part_1_check_full_list())
 input = open("advent_of_code_day2_input.txt","r")
 
 def part_2_password_check(lower_bound, upper_bound, rule_letter, password_to_test):
-  if rule_letter == password_to_test[lower_bound]:
-    first_condition = True 
-  else:
-    first_condition = False
-  if rule_letter == password_to_test[upper_bound]:
-    second_condition = True
-  else:
-    second_condition = False
-  return (first_condition != True
-          or second_condition != True) and (first_condition == True
-                                            or second_condition == True)
+  first_condition = rule_letter == password_to_test[lower_bound]
+  second_condition = rule_letter == password_to_test[upper_bound]
+  return (not first_condition
+          or not second_condition) and (first_condition or second_condition)
     
 
 def part_2_check_full_list():

--- a/advent_of_code_day4.py
+++ b/advent_of_code_day4.py
@@ -32,7 +32,7 @@ def part_1_passport_check_all(input_field, necessary_fields, optional_fields):
 
 part_1_answer = part_1_passport_check_all(input_file_name, necessary_fields, optional_fields)
 
-print("In part one there were %s valid passports" % part_1_answer)
+print(f"In part one there were {part_1_answer} valid passports")
 
 def passport_check_part_2(passport, necessary_fields):
   passport_status = "Valid"
@@ -60,67 +60,54 @@ def passport_check_part_2(passport, necessary_fields):
 def birth_year_validation(birth_year, current_passport_status):
   passport_status = current_passport_status
   birth_year = int(birth_year)
-  if birth_year > 2002:
+  if birth_year > 2002 or birth_year < 1920:
     passport_status = "Invalid"
-  elif birth_year < 1920:
-    passport_status = "Invalid"
-  print("Birth year is %s" % passport_status)
+  print(f"Birth year is {passport_status}")
   return passport_status
 
 def issue_year_validation(issue_year, current_passport_status):
   passport_status = current_passport_status
   issue_year = int(issue_year)
-  if issue_year > 2020:
+  if issue_year > 2020 or issue_year < 2010:
     passport_status = "Invalid"
-  elif issue_year < 2010:
-    passport_status = "Invalid"
-  print("Issue year is %s" % passport_status)
+  print(f"Issue year is {passport_status}")
   return passport_status
 
 def expiration_year_validation(expiration_year, current_passport_status):
   passport_status = current_passport_status
   expiration_year = int(expiration_year)
-  if expiration_year > 2030:
+  if expiration_year > 2030 or expiration_year < 2020:
     passport_status = "Invalid"
-  elif expiration_year < 2020:
-    passport_status = "Invalid"
-  print("Expiration year is %s" % passport_status)
+  print(f"Expiration year is {passport_status}")
   return passport_status
 
 def height_validation(height, current_passport_status):
   passport_status = current_passport_status
   if "cm" in height:
     cm_position = height.find("cm")
-    height_in_cm = int(height[0:cm_position])
-    if height_in_cm < 150:
-      passport_status = "Invalid"
-    elif height_in_cm > 193:
+    height_in_cm = int(height[:cm_position])
+    if height_in_cm < 150 or height_in_cm > 193:
       passport_status = "Invalid"
   elif "in" in height:
     inch_position = height.find("in")
-    height_in_inches = int(height[0:inch_position])
-    if height_in_inches < 59:
-      passport_status = "Invalid"
-    elif height_in_inches > 76:
+    height_in_inches = int(height[:inch_position])
+    if height_in_inches < 59 or height_in_inches > 76:
       passport_status = "Invalid"
   else:
     passport_status = "Invalid"
-  print("Height is %s" % passport_status)
+  print(f"Height is {passport_status}")
   return passport_status
 
 def hair_color_validation(hair_color, current_passport_status):
   passport_status = current_passport_status
-  valid_color_keys = ["0","1","2","3","4","5","6","7","8","9","a","b","c","d","e","f"]
-  if len(hair_color) != 7:
+  if len(hair_color) == 7 and hair_color[0] != "#" or len(hair_color) != 7:
     passport_status = "Invalid"
   else:
-    if hair_color[0] != "#":
-      passport_status = "Invalid"
-    else:
-      for character in range(1,len(hair_color),1):
-        if hair_color[character] not in valid_color_keys:
-          passport_status = "Invalid"
-  print("Hair color is %s" % passport_status)
+    valid_color_keys = ["0","1","2","3","4","5","6","7","8","9","a","b","c","d","e","f"]
+    for character in range(1, len(hair_color)):
+      if hair_color[character] not in valid_color_keys:
+        passport_status = "Invalid"
+  print(f"Hair color is {passport_status}")
   return passport_status
 
 def eye_color_validation(eye_color, current_passport_status):
@@ -128,19 +115,19 @@ def eye_color_validation(eye_color, current_passport_status):
   valid_colors = ["amb","blu","brn","gry","grn","hzl","oth"]
   if eye_color not in valid_colors:
     passport_status = "Invalid"
-  print("Eye color is %s" % passport_status)
+  print(f"Eye color is {passport_status}")
   return passport_status
 
 def passport_id_validation(passport_id, current_passport_status):
   passport_status = current_passport_status
-  valid_numbers = ["0","1","2","3","4","5","6","7","8","9"]
   if len(passport_id) != 9:
     passport_status = "Invalid"
   else:
+    valid_numbers = ["0","1","2","3","4","5","6","7","8","9"]
     for character in passport_id:
       if character not in valid_numbers:
         passport_status = "Invalid"
-  print("Passport_id is %s" % passport_status)
+  print(f"Passport_id is {passport_status}")
   return passport_status
 
 def part_2_passport_check_all(input_field, necessary_fields, optional_fields):
@@ -166,4 +153,4 @@ def part_2_passport_check_all(input_field, necessary_fields, optional_fields):
 
 part_2_answer = part_2_passport_check_all(input_file_name, necessary_fields, optional_fields)
 
-print("In part two there were %s valid passports" % part_2_answer)
+print(f"In part two there were {part_2_answer} valid passports")

--- a/advent_of_code_day5.py
+++ b/advent_of_code_day5.py
@@ -9,7 +9,7 @@ number_of_column_identities = 3
 def identify_row(boarding_pass, number_of_rows_on_plane, number_of_row_identities):
   min_row = 0
   max_row = number_of_rows_on_plane
-  for character in range(0, number_of_row_identities, 1):
+  for character in range(number_of_row_identities):
     if boarding_pass[character] == "F":
       max_row = math.floor((min_row + max_row) / 2)
     elif boarding_pass[character] == "B":
@@ -20,7 +20,7 @@ def identify_row(boarding_pass, number_of_rows_on_plane, number_of_row_identitie
 def identify_column(boarding_pass, number_of_columns_on_plane, number_of_row_identities, number_of_column_identities):
   min_column = 0
   max_column = number_of_columns_on_plane
-  for character in range(number_of_row_identities, (number_of_row_identities + number_of_column_identities), 1):
+  for character in range(number_of_row_identities, number_of_row_identities + number_of_column_identities):
     if boarding_pass[character] == "L":
       max_column = math.floor((min_column + max_column) / 2)
     elif boarding_pass[character] == "R":
@@ -44,7 +44,7 @@ def part_one(input_file):
 
 part_one_solution = part_one(input)
 
-print("The answer to part one is %s" % part_one_solution)
+print(f"The answer to part one is {part_one_solution}")
 
 def part_two(input_file):
   input = open(input_file, "r")
@@ -61,11 +61,12 @@ def part_two(input_file):
     if ticket_id < min_seat_id:
       min_seat_id = ticket_id
   your_seat = 0
-  for seat in range(min_seat_id, max_seat_id, 1):
+  for seat in range(min_seat_id, max_seat_id):
     if (seat - 1) in seat_id_list and (seat + 1) in seat_id_list and seat not in seat_id_list:
       your_seat = seat
   return your_seat
 
 your_seat_ticket = part_two(input)
 
-print("Your seat number is %s. Take your seat, its time to fly" % (your_seat_ticket))
+print(
+    f"Your seat number is {your_seat_ticket}. Take your seat, its time to fly")

--- a/advent_of_code_day6.py
+++ b/advent_of_code_day6.py
@@ -12,13 +12,14 @@ def part_one_customs_check(input_file):
       unique_answer_counts.append(len(current_group_unique_answers))
       current_group_unique_answers = []
     else:
-      for character in range(0, len(row), 1):
-        if (row[character] != "" or row[character] != "\n"
-            ) and row[character] not in current_group_unique_answers:
+      for character in range(len(row)):
+        if row[character] not in current_group_unique_answers:
           current_group_unique_answers.append(row[character])
   return np.sum(unique_answer_counts)
 
-print("The total number of unique answers in part one is %s" % part_one_customs_check(input))
+print(
+    f"The total number of unique answers in part one is {part_one_customs_check(input)}"
+)
 
 def part_two_customs_check(input_file):
   # sourcery skip: inline-immediately-returned-variable, merge-nested-ifs
@@ -34,13 +35,12 @@ def part_two_customs_check(input_file):
       group_row_counter = 0
     else:
       if group_row_counter == 0:
-        for character in range(0, len(row), 1):
-          if row[character] != "" or row[character] != "\n":
-            current_group_unanimous_answers.append(row[character])
+        for character in range(len(row)):
+          current_group_unanimous_answers.append(row[character])
       else:
        #Defines the answers for an individual in a group who isn't the first to answer
         current_individual_answers = [
-            row[character] for character in range(0, len(row), 1)
+            row[character] for character in range(len(row))
             if row[character] != "" or row[character] != "\n"
         ]
         #Need to create a temporary version of the group answers to iterate over
@@ -56,4 +56,6 @@ def part_two_customs_check(input_file):
   total_unique_answer_sum = np.sum(unique_answer_counts)
   return total_unique_answer_sum
 
-print("The total number of unique answers in part two is %s" % part_two_customs_check(input))
+print(
+    f"The total number of unique answers in part two is {part_two_customs_check(input)}"
+)

--- a/advent_of_code_day7.py
+++ b/advent_of_code_day7.py
@@ -6,7 +6,7 @@ def bag_parser(input_row):
   inner_bags = parsed_row[1].split(",")
   outer_bag = number_replacer(outer_bag)
   outer_bag = bags_to_bag(outer_bag)
-  for bag in range(0, len(inner_bags), 1):
+  for bag in range(len(inner_bags)):
     inner_bags[bag] = number_replacer(inner_bags[bag])
     inner_bags[bag] = bags_to_bag(inner_bags[bag])
   return outer_bag, inner_bags
@@ -77,7 +77,7 @@ def part_2_bag_parser(input_row):
   inner_bags = parsed_row[1].split(",")
   outer_bag = number_replacer(outer_bag)
   outer_bag = bags_to_bag(outer_bag)
-  for bag in range(0, len(inner_bags), 1):
+  for bag in range(len(inner_bags)):
     inner_bags[bag] = part_2_number_replacer(inner_bags[bag])
     inner_bags[bag] = bags_to_bag(inner_bags[bag])
   return outer_bag, inner_bags
@@ -86,24 +86,23 @@ def part_2(input_file):
   input = open(input_file, "r")
   bag_matrix = []
   outer_bags = []
-  bags_contained_by_outer_bag = {}
   for row in input:
     outer_bag, inner_bags = part_2_bag_parser(row)
     bag_matrix.append([outer_bag, inner_bags])
     if outer_bag not in outer_bags:
       outer_bags.append(outer_bag)
-  # Identify all bags that contain no other bags
-  for bag_set in bag_matrix:
-    if " no other bag" in bag_set[1]:
-      bags_contained_by_outer_bag[bag_set[0]] = 1
-  while len(bags_contained_by_outer_bag) < len(outer_bags):    
+  bags_contained_by_outer_bag = {
+      bag_set[0]: 1
+      for bag_set in bag_matrix if " no other bag" in bag_set[1]
+  }
+  while len(bags_contained_by_outer_bag) < len(outer_bags):
     for bag_set in bag_matrix:
       inner_bag_fully_defined = []
       for inner_bag in bag_set[1]:
-        if bags_contained_by_outer_bag.get(inner_bag[1:]) != None:
+        if bags_contained_by_outer_bag.get(inner_bag[1:]) is None: inner_bag_fully_defined.append(False)
+        else:
           inner_bag_fully_defined.append(True)
-        else: inner_bag_fully_defined.append(False)
-      if all(inner_bag_fully_defined) and len(inner_bag_fully_defined) != 0:
+      if all(inner_bag_fully_defined) and inner_bag_fully_defined:
         sub_bags = 0
         for sub_bag in bag_set[1]:
           sub_bags = sub_bags + int(sub_bag[0]) * bags_contained_by_outer_bag.get(sub_bag[1:])

--- a/advent_of_code_day8.py
+++ b/advent_of_code_day8.py
@@ -16,27 +16,24 @@ def part_1_solution(input):
   current_position = 0
   while current_position not in read_instructions:
     current_instruction = instructions[current_position]
-    instruction_type = current_instruction[0:3]
+    instruction_type = current_instruction[:3]
     cleaned_operator = current_instruction[3:].strip()
     direction = cleaned_operator[0]
     operator_value = int(cleaned_operator[1:])
-    if instruction_type == "nop":
+    if instruction_type == "acc":
+      accumulator_value = accumulator_value + operator_value if direction == "+" else accumulator_value - operator_value
       current_position += 1
       read_instructions.append(current_position - 1)
-    if instruction_type == "acc":
+    elif instruction_type == "jmp":
       if direction == "+":
-        accumulator_value = accumulator_value + operator_value
-      else:
-        accumulator_value = accumulator_value - operator_value
-      current_position += 1
-      read_instructions.append(current_position - 1)  
-    if instruction_type == "jmp":
-      if direction == "+":
-        current_position = current_position + operator_value
+        current_position += operator_value
         read_instructions.append(current_position - operator_value)
       else:
-        current_position = current_position - operator_value
+        current_position -= operator_value
         read_instructions.append(current_position + operator_value)
+    elif instruction_type == "nop":
+      current_position += 1
+      read_instructions.append(current_position - 1)
   return accumulator_value
 
 part_one_output = part_1_solution(input)
@@ -47,20 +44,18 @@ print(part_one_output)
 def part_2_solution(input):
   instructions = []
   instructions = convert_input_to_instructions(input)
-  for i in range(0, len(instructions), 1):
+  for i in range(len(instructions)):
     instruction = instructions[i]
-    instruction_type = instruction[0:3]
+    instruction_type = instruction[:3]
     temporary_instructions = []
     temporary_instructions = instructions
-    if instruction_type == "nop":
-      temp_instruction = "jmp"
-      temporary_instructions[i] = temp_instruction + instruction[3:]
-    elif instruction_type == "jmp":
+    if instruction_type == "jmp":
       temp_instruction = "nop"
-      temporary_instructions[i] = temp_instruction + instruction[3:]
+    elif instruction_type == "nop":
+      temp_instruction = "jmp"
     else:
       temp_instruction = "acc"
-      temporary_instructions[i] = temp_instruction + instruction[3:]
+    temporary_instructions[i] = temp_instruction + instruction[3:]
     loop_status, accumulator_value = part_2_loop(temporary_instructions)
     if loop_status == "Fixed":
       valid_accumulator_value = accumulator_value
@@ -75,11 +70,12 @@ def part_2_loop(instructions):
   current_position = 0
   while True:
     current_instruction = instructions[current_position]
-    instruction_type = current_instruction[0:3]
+    instruction_type = current_instruction[:3]
     cleaned_operator = current_instruction[3:].strip()
     direction = cleaned_operator[0]
     operator_value = int(cleaned_operator[1:])
-    if instruction_type == "nop":
+    if instruction_type == "acc":
+      accumulator_value = accumulator_value + operator_value if direction == "+" else accumulator_value - operator_value
       current_position += 1
       if current_position in read_instructions:
         loop_status = "Infinite"
@@ -88,20 +84,7 @@ def part_2_loop(instructions):
         loop_status = "Fixed"
         break
       read_instructions.append(current_position - 1)
-    if instruction_type == "acc":
-      if direction == "+":
-        accumulator_value = accumulator_value + operator_value
-      else:
-        accumulator_value = accumulator_value - operator_value
-      current_position += 1
-      if current_position in read_instructions:
-        loop_status = "Infinite"
-        break
-      elif current_position >= len(instructions):
-        loop_status = "Fixed"
-        break
-      read_instructions.append(current_position - 1)  
-    if instruction_type == "jmp":
+    elif instruction_type == "jmp":
       if direction == "+":
         current_position = current_position + operator_value
         if current_position in read_instructions:
@@ -119,9 +102,18 @@ def part_2_loop(instructions):
         elif current_position >= len(instructions):
           loop_status = "Fixed"
           break
-        read_instructions.append(current_position + operator_value) 
+        read_instructions.append(current_position + operator_value)
+    elif instruction_type == "nop":
+      current_position += 1
+      if current_position in read_instructions:
+        loop_status = "Infinite"
+        break
+      elif current_position >= len(instructions):
+        loop_status = "Fixed"
+        break
+      read_instructions.append(current_position - 1)
   return loop_status, accumulator_value
 
 part_two_output = part_2_solution(input)
-print("part 2 solution is %s" % part_two_output)
+print(f"part 2 solution is {part_two_output}")
     

--- a/advent_of_code_day_3.py
+++ b/advent_of_code_day_3.py
@@ -36,7 +36,7 @@ def full_slope_run_part_1(input_file, moves_to_the_right, moves_down):
 
 part_1_trees_hit = full_slope_run_part_1(input_file_name, moves_to_the_right, moves_down)
 
-print("In part 1 you encountered %s trees" % part_1_trees_hit)
+print(f"In part 1 you encountered {part_1_trees_hit} trees")
 
 #Takes the input slops in form [moves to the right, moves down]
 slope_matrix = [[1,1], [3,1], [5,1], [7,1], [1,2]]
@@ -47,11 +47,11 @@ def full_slope_run_part_2(input_file, slope_matrix):
   for run_counter, run in enumerate(slope_matrix, start=1):
     trees_hit = full_slope_run_part_1(input_file, run[0], run[1])
     run_results.append(trees_hit)
-    print("In part 2 run %s you encountered %s trees" % (run_counter, trees_hit))
+    print(f"In part 2 run {run_counter} you encountered {trees_hit} trees")
   return run_results
 
 part_2_results = np.prod(full_slope_run_part_2(input_file_name, slope_matrix))
 
-print("The overall part 2 results are %s" % part_2_results)
+print(f"The overall part 2 results are {part_2_results}")
 
 


### PR DESCRIPTION
Sourcery reviewed this PR. In addition to the diff, Sourcery flagged the following comments: 

Reviewed advent_of_code_day1.py
Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
   1 input = [1895, 1504, 1660, 1775, 1743, 1607, 1267, 1133, 292, 1646,                                       
   2 1285, 1808, 1512, 1839, 1869, 1578, 1318, 1385, 1829, 1800, 1491, 1600, 1290,                             
   3 1856, 1781, 1881, 1953, 2008, 1681, 1472, 1846, 2010, 1619, 1584, 1849, 1876,                             
   4 1744, 1980, 1421, 911, 1308, 1762, 1398, 1470, 1974, 1902, 1985, 2001, 1926,                              
   5 1374, 1678, 1523, 1894, 1597, 1778, 1940, 1362, 1613, 1629, 1473, 1633, 1867,                             
   6 1838, 1931, 1850, 1776, 1689, 1311, 1947, 1988, 1779, 1381, 1683, 1677, 1675,                             
   7 1587, 767, 1401, 1412, 1544, 1484, 618, 1755, 1073, 1970, 1735, 1770, 1623,                               
   8 1665, 1783, 1400, 1892, 1921, 1506, 1978, 1731, 1739, 1515, 1354, 1264, 1394,                             
   9 1763, 1569, 1453, 1539, 2006, 1586, 1855, 1609, 1729, 1624, 506, 1668, 1803,                              
  10 1486, 1767, 1720, 1753, 1994, 1718, 1922, 1314, 1250, 1516, 1546, 1625, 1708,                             
  11 1286, 1993, 1785, 491, 1705, 1924, 1752, 1888, 1651, 1604, 1750, 1547, 1481,                              
  12 1704, 1851, 904, 1920, 1939, 1277, 1870, 1934, 1617, 1833, 1797, 1817, 1967,                              
  13 1935, 1914, 1621, 1468, 1859, 1552, 1640, 1709, 1121, 1973, 1343, 1266, 1806,                             
  14 1360, 1299, 1990, 1356, 1631, 1555, 1811, 1323, 1794, 1550, 1448, 1848, 1826,                             
  15 1723, 1891, 1302, 1655, 947, 1580, 1908, 1641, 1816, 1701, 1871, 1588, 1843,                              
  16 1643, 1893, 1866, 1628, 1417, 1795, 1995, 1937]                                                           
  17                                                                                                           

Reviewed advent_of_code_day2.py
Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  1 input = open("advent_of_code_day2_input.txt","r")                                                          
  2                                                                                                            

Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  35 print(part_1_check_full_list())                                                                           
  36                                                                                                           
  37 input = open("advent_of_code_day2_input.txt","r")                                                         
  38                                                                                                           

Reviewed advent_of_code_day4.py
Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  15 def part_1_passport_check_all(input_field, necessary_fields, optional_fields):                            
  16   #Open input file and chunk out what is a passport                                                       
  17   input = open(input_field, "r")                                                                          
  18   current_passport = {}                                                                                   
  19                                                                                                           

Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  135 def part_2_passport_check_all(input_field, necessary_fields, optional_fields):                           
  136   #Open input file and chunk out what is a passport                                                      
  137   input = open(input_field, "r")                                                                         
  138   current_passport = {}                                                                                  
  139                                                                                                          

Reviewed advent_of_code_day5.py
Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  2 import math                                                                                                
  3 input = "advent_of_code_day_input.txt"                                                                     
  4                                                                                                            
  5                                                                                                            

Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  35 def part_one(input_file):                                                                                 
  36   input = open(input_file, "r")                                                                           
  37   max_seat_id = 0                                                                                         
  38                                                                                                           

Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  50 def part_two(input_file):                                                                                 
  51   input = open(input_file, "r")                                                                           
  52   max_seat_id = 0                                                                                         
  53                                                                                                           

Reviewed advent_of_code_day6.py
Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  3 import numpy as np                                                                                         
  4                                                                                                            
  5 input = "advent_of_code_day6_input.txt"                                                                    
  6                                                                                                            

Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  6 def part_one_customs_check(input_file):                                                                    
  7   input = open(input_file, "r")                                                                            
  8   current_group_unique_answers = []                                                                        
  9                                                                                                            

Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  26 def part_two_customs_check(input_file):                                                                   
  27   # sourcery skip: inline-immediately-returned-variable, merge-nested-ifs                                 
  28   input = open(input_file, "r")                                                                           
  29   current_group_unanimous_answers = []                                                                    
  30                                                                                                           

Reviewed advent_of_code_day7.py
Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  1 input = "advent_of_code_day7_input.txt"                                                                    
  2                                                                                                            

Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  46   i = 0                                                                                                   
  47   while i < len(target_bags):                                                                             
  48     input = open(input_file, "r")                                                                         
  49     for row in input:                                                                                     
  50                                                                                                           

Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  86 def part_2(input_file):                                                                                   
  87   input = open(input_file, "r")                                                                           
  88   bag_matrix = []                                                                                         
  89                                                                                                           

Reviewed advent_of_code_day8.py
Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  1 input = "advent_of_code_day8_input.txt"                                                                    
  2                                                                                                            
  3                                                                                                            

Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  6 def convert_input_to_instructions(input_file):                                                             
  7   input = open(input_file, "r")                                                                            
  8   for row in input:                                                                                        
  9                                                                                                            

Reviewed advent_of_code_day_3.py
Sourcery has identified the following issue:                                                                   

 • Don't assign to builtin variable input (avoid-builtin-shadow)                                               

Python has a number of builtin variables: functions and constants that form a part of the language, such as    
list, getattr, and type (See https://docs.python.org/3/library/functions.html). It is valid, in the language,  
to re-bind such variables:                                                                                     

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ list = [1, 2, 3]                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

However, this is considered poor practice.                                                                     

 • It will confuse other developers.                                                                           
 • It will confuse syntax highlighters and linters.                                                            
 • It means you can no longer use that builtin for its original purpose.                                       

How can you solve this?                                                                                        

Rename the variable something more specific, such as integers. In a pinch, my_list and similar names are       
colloquially-recognized placeholders.                                                                          
  24 def full_slope_run_part_1(input_file, moves_to_the_right, moves_down):                                    
  25   input = open(input_file,"r")                                                                            
  26   #Sets the count of trees encountered at 0 & starts you at the top left corner of the input              
  27   tree_counter = 0                                                                                        
  28   current_position = 0                                                                                    
  29   rows = input.readlines()                                                                                
  30                                                                                                           

